### PR TITLE
feat: scaffold new job service

### DIFF
--- a/services/job/go.mod
+++ b/services/job/go.mod
@@ -1,0 +1,7 @@
+module github.com/cduggn/cloud-nuke-orchestrator/services/job
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.6.0
+)

--- a/services/job/main.go
+++ b/services/job/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// TO-DO: implement main function
+}

--- a/services/job/ports/api.go
+++ b/services/job/ports/api.go
@@ -1,0 +1,19 @@
+package ports
+
+import "github.com/google/uuid"
+
+// API is the primary port for the job service
+type API interface {
+	// GetJobs retrieves a list of jobs, optionally filtered by status.
+	GetJobs(status []string) ([]Job, error)
+	// CreateJob creates a new job.
+	CreateJob(job JobCreate) (Job, error)
+	// GetJob retrieves a job by its ID.
+	GetJob(id uuid.UUID) (Job, error)
+	// GetJobOutcome retrieves the outcome of a job.
+	GetJobOutcome(id uuid.UUID) (JobOutcome, error)
+	// UpdateJobScheduler updates a job from the scheduler's perspective.
+	UpdateJobScheduler(id uuid.UUID, update JobSchedulerUpdate) (Job, error)
+	// UpdateJobWorkerDaemon updates a job from the worker daemon's perspective.
+	UpdateJobWorkerDaemon(id uuid.UUID, update JobWorkerDaemonUpdate) (Job, error)
+}

--- a/services/job/ports/model.go
+++ b/services/job/ports/model.go
@@ -1,0 +1,61 @@
+package ports
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Job struct {
+	ID              uuid.UUID              `json:"id"`
+	UserID          uuid.UUID              `json:"userId"`
+	JobName         string                 `json:"jobName"`
+	Image           ContainerImage         `json:"image"`
+	Parameters      map[string]string      `json:"parameters"`
+	CreationZone    string                 `json:"creationZone"`
+	Status          string                 `json:"status"`
+	CreatedAt       time.Time              `json:"createdAt"`
+	UpdatedAt       time.Time              `json:"updatedAt"`
+	Result          string                 `json:"result"`
+	WorkerID        uuid.UUID              `json:"workerId"`
+	ErrorMessage    string                 `json:"errorMessage"`
+	ComputeZone     string                 `json:"computeZone"`
+	CarbonIntensity int                    `json:"carbonIntensity"`
+	CarbonSavings   int                    `json:"carbonSavings"`
+}
+
+type JobCreate struct {
+	JobName      string            `json:"jobName"`
+	CreationZone string            `json:"creationZone"`
+	Image        ContainerImage    `json:"image"`
+	Parameters   map[string]string `json:"parameters"`
+}
+
+type ContainerImage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type JobOutcome struct {
+	JobName         string `json:"jobName"`
+	Status          string `json:"status"`
+	Result          string `json:"result"`
+	ErrorMessage    string `json:"errorMessage"`
+	ComputeZone     string `json:"computeZone"`
+	CarbonIntensity int    `json:"carbonIntensity"`
+	CarbonSavings   int    `json:"carbonSavings"`
+}
+
+type JobSchedulerUpdate struct {
+	WorkerID        uuid.UUID `json:"workerId"`
+	ComputeZone     string    `json:"computeZone"`
+	CarbonIntensity int       `json:"carbonIntensity"`
+	CarbonSavings   int       `json:"carbonSavings"`
+	Status          string    `json:"status"`
+}
+
+type JobWorkerDaemonUpdate struct {
+	Status       string `json:"status"`
+	Result       string `json:"result"`
+	ErrorMessage string `json:"errorMessage"`
+}

--- a/services/job/ports/model.go
+++ b/services/job/ports/model.go
@@ -51,11 +51,11 @@ type JobSchedulerUpdate struct {
 	ComputeZone     string    `json:"computeZone"`
 	CarbonIntensity int       `json:"carbonIntensity"`
 	CarbonSavings   int       `json:"carbonSavings"`
-	Status          string    `json:"status"`
+	Status          JobStatus `json:"status"`
 }
 
 type JobWorkerDaemonUpdate struct {
-	Status       string `json:"status"`
-	Result       string `json:"result"`
-	ErrorMessage string `json:"errorMessage"`
+	Status       JobStatus `json:"status"`
+	Result       string    `json:"result"`
+	ErrorMessage string    `json:"errorMessage"`
 }

--- a/services/job/ports/model.go
+++ b/services/job/ports/model.go
@@ -17,7 +17,7 @@ type Job struct {
 	CreatedAt       time.Time              `json:"createdAt"`
 	UpdatedAt       time.Time              `json:"updatedAt"`
 	Result          string                 `json:"result"`
-	WorkerID        uuid.UUID              `json:"workerId"`
+	WorkerID        *uuid.UUID             `json:"workerId"`
 	ErrorMessage    string                 `json:"errorMessage"`
 	ComputeZone     string                 `json:"computeZone"`
 	CarbonIntensity int                    `json:"carbonIntensity"`


### PR DESCRIPTION
create a new task for a job service that shall be located in the services/jobs folder. It shall eventually implement the api that is already defined in the api.yaml. The structure shall resemble the one from the services/entity folder. In this task only setup a basic structure of the service and define the api.gp in the ports folder. Don't implement adapters and core yet.